### PR TITLE
Updated settings to find components in gold DS

### DIFF
--- a/.changeset/young-moles-cheat.md
+++ b/.changeset/young-moles-cheat.md
@@ -1,0 +1,5 @@
+---
+"@gold.au/syrup": patch
+---
+
+Updated settings to find components in gold DS

--- a/packages/pancake-syrup/settings.json
+++ b/packages/pancake-syrup/settings.json
@@ -1,4 +1,4 @@
 {
 	"npmOrg": "@gold.au",
-	"json": "https://raw.githubusercontent.com/govau/design-system-components/master/auds.json"
+	"json": "https://raw.githubusercontent.com/designsystemau/gold-design-system/main/auds.json"
 }


### PR DESCRIPTION
It was still pointing at the `govau` repo.